### PR TITLE
docs: fix simple typo, occours -> occurs

### DIFF
--- a/test/qunit/qunit-1.17.1.js
+++ b/test/qunit/qunit-1.17.1.js
@@ -2788,7 +2788,7 @@ QUnit.log(function( details ) {
 
         message += "</table>";
 
-    // this occours when pushFailure is set and we have an extracted stack trace
+    // this occurs when pushFailure is set and we have an extracted stack trace
     } else if ( !details.result && details.source ) {
         message += "<table>" +
             "<tr class='test-source'><th>Source: </th><td><pre>" +


### PR DESCRIPTION
There is a small typo in test/qunit/qunit-1.17.1.js.

Should read `occurs` rather than `occours`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md